### PR TITLE
ci: add GitHub Actions CI workflow for PRs and main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '19'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build -x test
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/test/
+          retention-days: 7


### PR DESCRIPTION
Add a CI workflow that runs on all pull requests targeting main and on direct pushes to main. The workflow:

- Checks out the code
- Sets up Java 19 (Temurin) matching the jvmToolchain in build.gradle.kts
- Configures Gradle via the official gradle/actions/setup-gradle action
- Builds the project (excluding tests) to catch compilation errors fast
- Runs the full test suite (JUnit Jupiter via Gradle)
- Uploads test reports as a workflow artifact (retained 7 days)

Includes step-security/harden-runner for supply-chain security, consistent with other workflows in the org.

Fixes #11